### PR TITLE
Itachi546/refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "author": "Railgun Project Contributors",
-  "main": "index.js",
+  "main": "src/index.js",
   "types": "src/index.d.ts",
   "scripts": {
     "lint": "eslint",

--- a/src/sources/data-source.ts
+++ b/src/sources/data-source.ts
@@ -20,7 +20,7 @@ interface DataSource<T extends EVMBlock> {
    * For a live RPC provider this would be the last block processed
    * or the tip of the chain
    */
-  head: bigint;
+  head() : Promise<bigint>
 
   /**
    * Is the source still ingesting data, ie can you expect it to update?

--- a/src/sources/json-rpc/client.ts
+++ b/src/sources/json-rpc/client.ts
@@ -201,7 +201,7 @@ class JSONRPCClient {
    * Check if URL supports WebSocket
    * @returns Valid support ws or not
    */
-  get supportsWebSocket(): boolean {
+  get supportsWebSocket (): boolean {
     return this.#url.protocol === 'ws:' || this.#url.protocol === 'wss:'
   }
 
@@ -209,7 +209,7 @@ class JSONRPCClient {
    * Connect to WebSocket if supported
    * @returns Nothing. Will throw if ws is not supported. Will resolve and log if ok.
    */
-  async #connectWebSocket(): Promise<void> {
+  async #connectWebSocket (): Promise<void> {
     if (!this.supportsWebSocket) {
       throw new Error('WebSocket not supported for this URL')
     }
@@ -219,7 +219,6 @@ class JSONRPCClient {
       return this.#wsConnected
     }
 
-
     this.#wsConnected = new Promise((resolve, reject) => {
       const wsUrl = this.#url.toString()
       this.#log(`[JSONRPCClient] Connecting to WebSocket: ${wsUrl}`)
@@ -227,16 +226,27 @@ class JSONRPCClient {
       this.#ws = new WebSocket(wsUrl)
 
       // Connects to ws
+      /**
+       * Websocket open callback
+       */
       this.#ws.onopen = () => {
         this.#log('[JSONRPCClient] WebSocket connected')
         resolve()
       }
 
+      /**
+       * Websocket error callback
+       * @param error - Error description
+       */
       this.#ws.onerror = (error) => {
         this.#log(`[JSONRPCClient] WebSocket error: ${error}`)
         reject(error)
       }
 
+      /**
+       * Websocket event callback
+       * @param event - Event data
+       */
       this.#ws.onmessage = (event) => {
         try {
           // Receives new message, parse data
@@ -247,6 +257,9 @@ class JSONRPCClient {
         }
       }
 
+      /**
+       * Websocket close callback
+       */
       this.#ws.onclose = () => {
         this.#log('[JSONRPCClient] WebSocket disconnected')
         this.#ws = null
@@ -259,12 +272,12 @@ class JSONRPCClient {
 
   /**
    * Handle incoming WebSocket messages
+   * @param data - JSONRPC Data
    */
-  #handleWebSocketMessage(data: any): void {
+  #handleWebSocketMessage (data: any): void {
     // Supported method from json rpc atm
     console.log('handleWebSocketMessage: ', data)
     if (data.method === 'eth_subscription') {
-
       const subscriptionId = data.params?.subscription
       const result = data.params?.result
 
@@ -285,7 +298,7 @@ class JSONRPCClient {
    * @param handler - Event handler function
    * @returns Subscription ID
    */
-  async subscribe(type: string, params: any, handler: SubscriptionHandler): Promise<string> {
+  async subscribe (type: string, params: any, handler: SubscriptionHandler): Promise<string> {
     if (!this.supportsWebSocket) {
       throw new Error('WebSocket subscriptions not supported for this URL')
     }
@@ -308,6 +321,10 @@ class JSONRPCClient {
         reject(new Error('Subscription request timeout'))
       }, 10000)
 
+      /**
+       * Websocket mssage handler
+       * @param event - MessageEvent
+       */
       const onMessage = (event: MessageEvent) => {
         try {
           const response = JSON.parse(event.data)
@@ -344,7 +361,7 @@ class JSONRPCClient {
    * Unsubscribe from events
    * @param subscriptionId - Subscription ID to unsubscribe
    */
-  async unsubscribe(subscriptionId: string): Promise<void> {
+  async unsubscribe (subscriptionId: string): Promise<void> {
     if (!this.#ws || !this.#subscriptions.has(subscriptionId)) {
       return
     }
@@ -363,7 +380,7 @@ class JSONRPCClient {
   /**
    * Close WebSocket connection and clean up subscriptions
    */
-  destroy(): void {
+  destroy (): void {
     if (this.#ws) {
       this.#ws.close()
       this.#ws = null

--- a/src/sources/subsquid/provider.ts
+++ b/src/sources/subsquid/provider.ts
@@ -27,9 +27,6 @@ type SubsquidEvmBlock = {
  * This is a placeholder for future implementation
  */
 export class SubsquidProvider<T extends EVMBlock> implements DataSource<T> {
-  /** The latest height up to which this provider can get data */
-  head = 0n
-
   /** Flag to indicate if the data-source can provide live data or not */
   isLiveProvider = false
 
@@ -44,7 +41,16 @@ export class SubsquidProvider<T extends EVMBlock> implements DataSource<T> {
     this.#client = new SubsquidClient({
       customSubsquidUrl: endpoint
     })
-    this.#getBlockHeight().then(height => { this.head = height })
+  }
+
+  /**
+   * Get the current head of subsquid, this is not necessarily the
+   * block upto which iterator can provide data because this value changes
+   * every time new blocks are indexed in the subsquid
+   * @returns - Latest height of the subsquid
+   */
+  head () {
+    return this.#getBlockHeight()
   }
 
   /**

--- a/test/graph-provider.test.ts
+++ b/test/graph-provider.test.ts
@@ -100,6 +100,12 @@ describe('GraphProvider[Ethereum]', () => {
     assert.ok(iterator2Count >= 0, 'Iterator2 should process events (may be 0 if no events in range)')
   })
 
+  test('Should fetch the current head', async () => {
+    const provider = new SubsquidProvider(MOCK_SQUID_URL)
+    const head = await provider.head()
+    assert.ok(head)
+  })
+
   test('Should retrieve exact number of events from fixed set of blocks', async () => {
     const provider = new SubsquidProvider(MOCK_SQUID_URL)
 

--- a/test/jsonrpc-provider.test.ts
+++ b/test/jsonrpc-provider.test.ts
@@ -9,7 +9,7 @@ dotenv.config()
 
 const RAILGUN_PROXY_ADDRESS = '0xFA7093CDD9EE6932B4eb2c9e1cde7CE00B1FA4b9'
 
-describe('JSONRPCProvider', () => {
+describe('JSONRPCProvider[ETHEREUM]', () => {
   const RPC_URL = process.env['RPC_API_KEY']!
   const WS_URL = process.env['WS_API_KEY']!
 
@@ -35,8 +35,7 @@ describe('JSONRPCProvider', () => {
         assert.ok(typeof subscriptionId === 'string', 'WebSocket channel should work')
 
         client.destroy()
-
-  } catch (error) {
+      } catch (error) {
         client.destroy()
         assert.ok(true, 'HTTP channel works, WebSocket may fail in test env')
       }
@@ -306,7 +305,7 @@ describe('JSONRPCProvider', () => {
     })
 
     test('Should handle unknown events gracefully without breaking', async () => {
-      const provider = new JSONRPCProvider(RAILGUN_PROXY_ADDRESS, RPC_URL,1000, false)
+      const provider = new JSONRPCProvider(RAILGUN_PROXY_ADDRESS, RPC_URL, 1000, false)
 
       const startBlock = 14777791n
       const endBlock = 14777795n
@@ -425,7 +424,6 @@ describe('JSONRPCProvider', () => {
         client.destroy()
 
         assert.ok(true, 'Should handle subscription lifecycle without errors')
-
       } catch (error) {
         client.destroy()
         console.log('WebSocket lifecycle test failed (may be expected):', error instanceof Error ? error.message : error)
@@ -453,7 +451,7 @@ describe('JSONRPCProvider', () => {
           liveSync: true
         })
 
-        const timeoutPromise = new Promise((_, reject) => {
+        const timeoutPromise = new Promise((_resolve, reject) => {
           setTimeout(() => reject(new Error('Test timeout - no live events received')), timeout)
         })
 
@@ -477,7 +475,6 @@ describe('JSONRPCProvider', () => {
 
         assert.ok(eventCount > 0, 'Should receive at least one live event')
         assert.ok(eventCount >= 1, `Should receive events, got ${eventCount}`)
-
       } catch (error) {
         if (error instanceof Error && error.message.includes('timeout')) {
           console.log('WebSocket test timed out - this may be expected if network is quiet')

--- a/test/jsonrpc-provider.test.ts
+++ b/test/jsonrpc-provider.test.ts
@@ -111,6 +111,17 @@ describe('JSONRPCProvider[ETHEREUM]', () => {
   })
 
   describe('JSONRPCProvider', () => {
+    test('Should create provider and fetch head', async () => {
+      const provider = new JSONRPCProvider(
+        RAILGUN_PROXY_ADDRESS,
+        RPC_URL,
+        1000,
+        true
+      )
+      const head = await provider.head()
+      assert.ok(head)
+    })
+
     test('Should create provider and retrieve blockchain data', async () => {
       const provider = new JSONRPCProvider(
         RAILGUN_PROXY_ADDRESS,

--- a/test/rpc-provider.test.ts
+++ b/test/rpc-provider.test.ts
@@ -16,7 +16,7 @@ const RAILGUN_DEPLOYMENT_V2 = 16076750n
 // TODO: Keep track of range of pre defined set of events
 // Verify that both iterators assert same amount of events
 
-describe('RPCProvider', () => {
+describe('RPCProvider[Ethereum]', () => {
   test('Should create an iterator from a provider', async () => {
     const connectionManager = new RPCConnectionManager(3)
     const provider = new RPCProvider(

--- a/test/rpc-provider.test.ts
+++ b/test/rpc-provider.test.ts
@@ -409,15 +409,15 @@ describe('RPCProvider[Ethereum]', () => {
   test('Should continously update the head', async () => {
     const connectionManager = new RPCConnectionManager(1)
     const provider = new RPCProvider(RAILGUN_PROXY_ADDRESS, MOCK_RPC_URL, connectionManager)
-    const lastHead = provider.head
+    const lastHead = await provider.head()
 
     // Wait until the next block is available
     await new Promise((resolve) => {
       setTimeout(resolve, 12_000)
     })
-    const newHead = provider.head
+    const newHead = await provider.head()
 
-    await provider.destroy()
+    provider.destroy()
     assert.notEqual(lastHead, newHead)
   })
 
@@ -539,12 +539,7 @@ describe('RPCProvider[Ethereum]', () => {
     const provider = new RPCProvider(RAILGUN_PROXY_ADDRESS, MOCK_RPC_URL, connectionManager)
 
     // Provider need to setup poller to get latest head which takes some time
-    const latestHeight = await new Promise<bigint>((resolve) => {
-      setTimeout(() => {
-        resolve(provider.head)
-      }, 5000)
-    })
-
+    const latestHeight = await provider.head()
     setTimeout(() => {
       provider.destroy()
     }, 5000)


### PR DESCRIPTION
The PR introduces following changes

1. Add missing JSDOC in JSONRpcProvider
2. Replace the polling of latest head logic in all the provider with async function
    Since we are only using the head outside of the provider, there is no need to setup an interval to continuously poll for the head. For every request we directly query rpc/subsquid and fetch the head.
