### PR TITLE
fix(package): scope package name under @railgun-reloaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "scanner",
+  "name": "@railgun-reloaded/scanner",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "scanner",
+      "name": "@railgun-reloaded/scanner",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scanner",
+  "name": "@railgun-reloaded/scanner",
   "version": "0.0.1",
   "description": "DataSync Repo for RAILGUN",
   "homepage": "https://github.com/railgun-reloaded/scanner#readme",


### PR DESCRIPTION
## Summary
- Renames the package from `scanner` to `@railgun-reloaded/scanner` in `package.json`
- Regenerates `package-lock.json` to reflect the new name

## Why
Every other package in the reloaded workspace is published under the `@railgun-reloaded/*` scope, and every consumer of this package (balance-scanner, rd-wallet, wallet-node, wallet-sdk) already imports it as `@railgun-reloaded/scanner`. The mismatch between the imported specifier and the package's own `name` field is what lets consumers that declare the dep under the unscoped key (wallet-sdk) "work" while consumers that use the correct scoped key end up with empty `node_modules/@railgun-reloaded/scanner` directories next to a populated `node_modules/scanner`. Renaming the package fixes both failure modes.

## Follow-up
wallet-sdk still declares this dep under the unscoped key `"scanner"` and will be fixed in a separate PR that must merge close to this one.