### PR TITLE
add: lastIteratedHeight readonly for wallet-sdk

### DIFF
--- a/src/sources/source-aggregator.ts
+++ b/src/sources/source-aggregator.ts
@@ -14,6 +14,15 @@ class SourceAggregator<T extends EVMBlock> {
    */
   #sources: DataSource<T>[] = []
 
+  #lastIteratedHeight: bigint | undefined
+
+  /**
+   * Highest block height the aggregator has covered during the latest sync.
+   */
+  get lastIteratedHeight (): bigint | undefined {
+    return this.#lastIteratedHeight
+  }
+
   /**
    * Initialize the aggregated source list of data source
    * @param sources - Sources to aggregate
@@ -31,7 +40,13 @@ class SourceAggregator<T extends EVMBlock> {
    * @returns AsyncGenerator that returns EVMBlock
    * @yields T
    */
-  async * from (options: SyncOptions) : AsyncGenerator<T> {
+  from (options: SyncOptions) : AsyncGenerator<T> {
+    this.#lastIteratedHeight = undefined
+
+    return this.#from(options)
+  }
+
+  async * #from (options: SyncOptions) : AsyncGenerator<T> {
     let { startHeight, endHeight, chunkSize } = options
 
     for (const source of this.#sources) {
@@ -48,7 +63,8 @@ class SourceAggregator<T extends EVMBlock> {
       }
 
       // Check if the source is upto date and discard it
-      if (sourceEnd && startHeight > sourceEnd) {
+      if (sourceEnd !== undefined && startHeight > sourceEnd) {
+        this.#setLastIteratedHeight(sourceEnd)
         continue
       }
 
@@ -57,14 +73,28 @@ class SourceAggregator<T extends EVMBlock> {
       // which leads to missing data or duplicate data
       // To prevent that, we query the block height before syncing and set endHeight to that height
       // for provider that doesn't use liveSync
-      yield * source.from({
+      for await (const block of source.from({
         startHeight,
-        liveSync: !sourceEnd,
+        liveSync: sourceEnd === undefined,
         endHeight: sourceEnd,
         chunkSize
-      })
+      })) {
+        this.#setLastIteratedHeight(block.number)
+        yield block
+      }
+
+      if (sourceEnd !== undefined) {
+        this.#setLastIteratedHeight(sourceEnd)
+      }
+
       // Shouldn't reach here in case of liveSync
-      startHeight = sourceEnd ? sourceEnd + 1n : startHeight
+      startHeight = sourceEnd !== undefined ? sourceEnd + 1n : startHeight
+    }
+  }
+
+  #setLastIteratedHeight (height: bigint) {
+    if (this.#lastIteratedHeight === undefined || height > this.#lastIteratedHeight) {
+      this.#lastIteratedHeight = height
     }
   }
 

--- a/test/source-aggregator.test.ts
+++ b/test/source-aggregator.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert'
+import { describe, test } from 'node:test'
+
+import type { EVMBlock } from '../src/models'
+import type { DataSource, SyncOptions } from '../src/sources/data-source'
+import { SourceAggregator } from '../src/sources/source-aggregator'
+
+class MockSource implements DataSource<EVMBlock> {
+  fromCalls: SyncOptions[] = []
+
+  constructor (
+    private readonly headHeight: bigint,
+    readonly isLiveProvider: boolean,
+    private readonly blocks: EVMBlock[] = []
+  ) {}
+
+  async head (): Promise<bigint> {
+    return this.headHeight
+  }
+
+  async * from (options: SyncOptions): AsyncGenerator<EVMBlock> {
+    this.fromCalls.push(options)
+
+    for (const block of this.blocks) {
+      yield block
+    }
+  }
+
+  destroy (): void {}
+}
+
+const makeBlock = (number: bigint): EVMBlock => ({
+  number,
+  hash: new Uint8Array(),
+  timestamp: 0n,
+  transactions: []
+})
+
+const collect = async (iterator: AsyncGenerator<EVMBlock>): Promise<EVMBlock[]> => {
+  const blocks: EVMBlock[] = []
+
+  for await (const block of iterator) {
+    blocks.push(block)
+  }
+
+  return blocks
+}
+
+describe('SourceAggregator', () => {
+  test('resets lastIteratedHeight when from is called', async () => {
+    const source = new MockSource(5n, false, [makeBlock(5n)])
+    const aggregator = new SourceAggregator([source])
+
+    await collect(aggregator.from({
+      startHeight: 5n,
+      endHeight: 5n,
+      liveSync: false
+    }))
+
+    assert.strictEqual(aggregator.lastIteratedHeight, 5n)
+
+    const iterator = aggregator.from({
+      startHeight: 6n,
+      endHeight: 6n,
+      liveSync: false
+    })
+
+    assert.strictEqual(aggregator.lastIteratedHeight, undefined)
+    await iterator.return(undefined)
+  })
+
+  test('sets lastIteratedHeight to finite sourceEnd when no blocks are yielded', async () => {
+    const source = new MockSource(12n, false)
+    const aggregator = new SourceAggregator([source])
+
+    const blocks = await collect(aggregator.from({
+      startHeight: 5n,
+      endHeight: 20n,
+      liveSync: false
+    }))
+
+    assert.deepStrictEqual(blocks, [])
+    assert.strictEqual(aggregator.lastIteratedHeight, 12n)
+  })
+
+  test('updates lastIteratedHeight for yielded event-bearing blocks', async () => {
+    const source = new MockSource(20n, false, [
+      makeBlock(7n),
+      makeBlock(11n)
+    ])
+    const aggregator = new SourceAggregator([source])
+    const yieldedHeights: bigint[] = []
+
+    for await (const block of aggregator.from({
+      startHeight: 5n,
+      endHeight: 20n,
+      liveSync: false
+    })) {
+      yieldedHeights.push(block.number)
+      assert.strictEqual(aggregator.lastIteratedHeight, block.number)
+    }
+
+    assert.deepStrictEqual(yieldedHeights, [7n, 11n])
+    assert.strictEqual(aggregator.lastIteratedHeight, 20n)
+  })
+
+  test('records finite sourceEnd for skipped sources', async () => {
+    const source = new MockSource(10n, false)
+    const aggregator = new SourceAggregator([source])
+
+    const blocks = await collect(aggregator.from({
+      startHeight: 15n,
+      endHeight: 20n,
+      liveSync: false
+    }))
+
+    assert.deepStrictEqual(blocks, [])
+    assert.deepStrictEqual(source.fromCalls, [])
+    assert.strictEqual(aggregator.lastIteratedHeight, 10n)
+  })
+})


### PR DESCRIPTION
fixes SourceAggregator coverage tracking by adding a read-only lastIteratedHeight cursor that wallet-sdk can use to persist scan progress even when upstream providers only yield event-bearing blocks.
