### PR TITLE
chore: add prepare script so git+https consumers build automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "eslint --fix",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
+    "prepare": "tsc --build",
     "pretest": "npm run build",
     "test": "node --test --enable-source-maps test/*.test.js",
     "coverage": "c8 --reporter=text --reporter=html --exclude=test npm test"


### PR DESCRIPTION
Without `prepare`, consumers that install this package via a git URL receive only the TypeScript source and no compiled `.js`. Adding `prepare: tsc --build` runs the TypeScript compiler at install time so the consumer ends up with the compiled output as if installed from npm. `prepare` runs automatically when installing git dependencies per npm's lifecycle scripts contract. Matching one-line PRs are going up across the other reloaded repos that need it.