### PR TITLE
feat: verify fetch cid / promote cid helpers 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@ipld/dag-cbor": "^9.2.7",
         "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
         "@railgun-reloaded/contract-abis": "^1.0.1",
         "@railgun-reloaded/subsquid-client": "https://github.com/railgun-reloaded/subsquid-client.git#v0.0.1",
-        "cbor2": "^2.2.1",
+        "cborg": "^5.1.1",
+        "multiformats": "^13.4.2",
         "viem": "^2.31.4"
       },
       "devDependencies": {
@@ -39,15 +41,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@cto.af/wtf8": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@cto.af/wtf8/-/wtf8-0.0.5.tgz",
-      "integrity": "sha512-LfUFi+Vv4eDzj+XAtR89e3wwjXA/NZjUSwU5NhwbBrLecxPaBYFy3exCuc1j+D4UZeOVdqlsl8G7LmOt18V0tg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {
@@ -320,6 +313,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.2.7",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.7.tgz",
+      "integrity": "sha512-ZmfXmElRWATr+hoUTSAOr6HUcjVhOcNHDqgczc76qte2DHHFEK0ZhNzUcdTDQhF/VSIvf2ioaRTRLWwLc83sNw==",
+      "dependencies": {
+        "cborg": "^5.0.1",
+        "multiformats": "^13.1.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1584,16 +1586,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/cbor2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-2.3.0.tgz",
-      "integrity": "sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@cto.af/wtf8": "0.0.5"
-      },
-      "engines": {
-        "node": ">=20"
+    "node_modules/cborg": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
+      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/chalk": {
@@ -3824,6 +3822,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "railgun-reloaded"
   ],
   "dependencies": {
+    "@ipld/dag-cbor": "^9.2.7",
     "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
     "@railgun-reloaded/contract-abis": "^1.0.1",
     "@railgun-reloaded/subsquid-client": "https://github.com/railgun-reloaded/subsquid-client.git#v0.0.1",
-    "cbor2": "^2.2.1",
+    "cborg": "^5.1.1",
+    "multiformats": "^13.4.2",
     "viem": "^2.31.4"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './models'
-export { RPCProvider, RPCConnectionManager, SubsquidProvider, SnapshotProvider, SourceAggregator } from './sources'
+export { RPCProvider, RPCConnectionManager, SubsquidProvider, SnapshotProvider, SourceAggregator, dagCborCIDFromBytes, verifyDagCborCID } from './sources'
 export { extractRailgunTransactions, RailgunTxidVersion } from './railgun-transactions'
 export type { ScannedRailgunTransaction, ScannedRailgunTransactionUnshield } from './railgun-transactions'

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,4 +1,4 @@
 export { RPCProvider, RPCConnectionManager } from './rpc'
 export { SubsquidProvider } from './subsquid'
-export { SnapshotProvider } from './snapshot'
+export { SnapshotProvider, dagCborCIDFromBytes, verifyDagCborCID } from './snapshot'
 export { SourceAggregator } from './source-aggregator'

--- a/src/sources/snapshot/cid.ts
+++ b/src/sources/snapshot/cid.ts
@@ -1,0 +1,51 @@
+/**
+ * Compute the producer-compatible CIDv1 for snapshot artifact bytes.
+ * @param bytes - Compressed snapshot artifact bytes.
+ * @returns Base32 CIDv1 using dag-cbor and sha2-256.
+ */
+async function dagCborCIDFromBytes (bytes: Uint8Array): Promise<string> {
+  const [
+    dagCbor,
+    { CID },
+    { sha256 }
+  ] = await Promise.all([
+    import('@ipld/dag-cbor'),
+    import('multiformats/cid'),
+    import('multiformats/hashes/sha2')
+  ])
+
+  const hash = await sha256.digest(bytes)
+  return CID.createV1(dagCbor.code, hash).toString()
+}
+
+/**
+ * Verify snapshot artifact bytes against an expected CID.
+ * @param bytes - Compressed snapshot artifact bytes.
+ * @param expectedCid - CID configured for the snapshot.
+ */
+async function verifyDagCborCID (
+  bytes: Uint8Array,
+  expectedCid: string
+): Promise<void> {
+  const [{ CID }, actualCid] = await Promise.all([
+    import('multiformats/cid'),
+    dagCborCIDFromBytes(bytes)
+  ])
+
+  let expected
+  try {
+    expected = CID.parse(expectedCid)
+  } catch (err) {
+    throw new Error(`Invalid expected snapshot CID: ${expectedCid}`, {
+      cause: err
+    })
+  }
+
+  if (!CID.parse(actualCid).equals(expected)) {
+    throw new Error(
+      `Snapshot CID mismatch: expected ${expectedCid}, got ${actualCid}`
+    )
+  }
+}
+
+export { dagCborCIDFromBytes, verifyDagCborCID }

--- a/src/sources/snapshot/index.ts
+++ b/src/sources/snapshot/index.ts
@@ -1,1 +1,2 @@
 export { SnapshotProvider } from './provider'
+export { dagCborCIDFromBytes, verifyDagCborCID } from './cid'

--- a/src/sources/snapshot/provider.ts
+++ b/src/sources/snapshot/provider.ts
@@ -6,13 +6,13 @@ import type { DataSource, SyncOptions } from '../data-source'
 import { flattenMemo } from '../formatters/memo'
 import { minBigInt } from '../formatters/subsquid/bigint'
 
+import { verifyDagCborCID } from './cid'
+
 type Snapshot = {
   version: number
   chainID: number
-  // This is encoded as BigInt while exporting, but cbor encoder
-  // converts it into the number
-  startHeight: number
-  endHeight: number
+  startHeight: bigint
+  endHeight: bigint
   entryCount: number
   blocks: EVMBlock[]
 }
@@ -49,6 +49,85 @@ function canonicalizeSnapshotBlockMemos<T extends EVMBlock> (block: T): T {
     }
   }
   return block
+}
+
+/**
+ * Convert a decoded snapshot height to the scanner's bigint representation.
+ * @param value - Decoded height value.
+ * @param fieldName - Field name used in validation errors.
+ * @returns Normalized bigint height.
+ */
+function normalizeHeight (value: unknown, fieldName: string): bigint {
+  if (typeof value === 'bigint') {
+    return value
+  }
+
+  if (typeof value === 'number' && Number.isSafeInteger(value)) {
+    return BigInt(value)
+  }
+
+  throw new Error(`Invalid snapshot: missing or invalid ${fieldName}`)
+}
+
+/**
+ * Normalize snapshot range metadata.
+ * @param snapshot - Decoded snapshot.
+ * @returns Snapshot with bigint range metadata.
+ */
+function normalizeSnapshotHeights (snapshot: Snapshot): Snapshot {
+  snapshot.startHeight = normalizeHeight(snapshot.startHeight, 'startHeight')
+  snapshot.endHeight = normalizeHeight(snapshot.endHeight, 'endHeight')
+  return snapshot
+}
+
+/**
+ * Normalize every decoded block number.
+ * @param snapshot - Validated decoded snapshot.
+ * @returns Snapshot with bigint block numbers.
+ */
+function normalizeSnapshotBlockHeights (snapshot: Snapshot): Snapshot {
+  snapshot.blocks = snapshot.blocks.map(block => {
+    block.number = normalizeHeight(block.number, 'block number')
+    return block
+  })
+  return snapshot
+}
+
+/**
+ * Decode DAG-CBOR with the producer's extended BigInt tag support.
+ * @param data - Decompressed snapshot bytes.
+ * @returns Decoded DAG-CBOR value.
+ */
+async function decodeDagCbor<T> (data: Uint8Array): Promise<T> {
+  const [
+    dagCbor,
+    { decode },
+    { bigIntDecoder, bigNegIntDecoder }
+  ] = await Promise.all([
+    import('@ipld/dag-cbor'),
+    import('cborg'),
+    import('cborg/taglib')
+  ])
+
+  try {
+    return dagCbor.decode(data) as T
+  } catch (err) {
+    if (
+      !(err instanceof Error) ||
+      !/tag not supported \([23]\)/.test(err.message)
+    ) {
+      throw err
+    }
+  }
+
+  return decode(dagCbor.toByteView(data), {
+    ...dagCbor.decodeOptions,
+    tags: {
+      ...dagCbor.decodeOptions.tags,
+      2: bigIntDecoder,
+      3: bigNegIntDecoder
+    }
+  }) as T
 }
 
 /**
@@ -108,12 +187,16 @@ export class SnapshotProvider<T extends EVMBlock> implements DataSource<T> {
           throw new Error(`Failed to get snapshot status: ${response.status}`)
         }
         const buffer = await response.arrayBuffer()
+        await verifyDagCborCID(new Uint8Array(buffer), this.#ipfsHash)
         return this.#decodeSnapshot(buffer)
       } catch (err) {
         lastError = err as Error
       }
     }
-    throw new Error('Failed to fetch snapshot', { cause: lastError })
+    const causeMessage = lastError ? `: ${lastError.message}` : ''
+    throw new Error(`Failed to fetch snapshot${causeMessage}`, {
+      cause: lastError
+    })
   }
 
   /**
@@ -129,10 +212,10 @@ export class SnapshotProvider<T extends EVMBlock> implements DataSource<T> {
       throw new Error('Invalid snapshot: missing or invalid chainID')
     }
 
-    if (typeof snapshot.startHeight !== 'number') {
+    if (typeof snapshot.startHeight !== 'bigint') {
       throw new Error('Invalid snapshot: missing or invalid startHeight')
     }
-    if (typeof snapshot.endHeight !== 'number') {
+    if (typeof snapshot.endHeight !== 'bigint') {
       throw new Error('Invalid snapshot: missing or invalid endHeight')
     }
 
@@ -153,10 +236,10 @@ export class SnapshotProvider<T extends EVMBlock> implements DataSource<T> {
   async #decodeSnapshot (rawContent: ArrayBuffer) {
     // We can use pipeline stream later
     try {
-      const { decode } = await import('cbor2')
       const decompressed = brotliDecompressSync(rawContent)
-      const snapshot = decode(decompressed) as Snapshot
+      const snapshot = normalizeSnapshotHeights(await decodeDagCbor<Snapshot>(decompressed))
       this.#validateSnapshot(snapshot)
+      normalizeSnapshotBlockHeights(snapshot)
       snapshot.blocks = snapshot.blocks.map(canonicalizeSnapshotBlockMemos)
       return snapshot
     } catch (err) {
@@ -174,7 +257,7 @@ export class SnapshotProvider<T extends EVMBlock> implements DataSource<T> {
     }
 
     if (this.snapshotContent) {
-      return BigInt(this.snapshotContent.endHeight)
+      return this.snapshotContent.endHeight
     } else {
       throw new Error('Failed to fetch head')
     }
@@ -203,8 +286,8 @@ export class SnapshotProvider<T extends EVMBlock> implements DataSource<T> {
       throw new Error('Failed to fetch snapshot')
     }
 
-    const snapshotStartHeight = BigInt(this.snapshotContent.startHeight)
-    const snapshotEndHeight = BigInt(this.snapshotContent.endHeight)
+    const snapshotStartHeight = this.snapshotContent.startHeight
+    const snapshotEndHeight = this.snapshotContent.endHeight
 
     if (_options.startHeight < snapshotStartHeight) {
       throw new Error(`Requested startHeight ${_options.startHeight} is less than snapshot start height ${snapshotStartHeight}. Some block range are missing in the snapshot`)

--- a/test/fixtures/snapshot-cid-fixture.ts
+++ b/test/fixtures/snapshot-cid-fixture.ts
@@ -1,3 +1,7 @@
+// Shared producer/consumer CID vector. This value is duplicated verbatim in
+// snapshot/test/fixtures/snapshot-cid-fixture.ts and MUST stay byte-identical:
+// each repo asserts its own CID helper reproduces `cid` from `artifactHex`, so
+// any drift between the two implementations fails that repo's parity test.
 const SNAPSHOT_CID_FIXTURE = {
   artifactHex: '7261696c67756e2d736e617073686f742d6369642d7631',
   cid: 'bafyreigennh5c6abpgadzpwjooykj67jvbii5cl5hjjhzq5dtesl3rgqgu'

--- a/test/fixtures/snapshot-cid-fixture.ts
+++ b/test/fixtures/snapshot-cid-fixture.ts
@@ -1,0 +1,6 @@
+const SNAPSHOT_CID_FIXTURE = {
+  artifactHex: '7261696c67756e2d736e617073686f742d6369642d7631',
+  cid: 'bafyreigennh5c6abpgadzpwjooykj67jvbii5cl5hjjhzq5dtesl3rgqgu'
+} as const
+
+export { SNAPSHOT_CID_FIXTURE }

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,76 +1,190 @@
 import assert from 'node:assert'
-import { before, describe, mock, test } from 'node:test'
+import { afterEach, describe, mock, test } from 'node:test'
 import { brotliCompressSync } from 'node:zlib'
 
-import { encode } from 'cbor2'
-import dotenv from 'dotenv'
+import { SnapshotProvider } from '../src/sources'
+import { dagCborCIDFromBytes } from '../src/sources/snapshot/cid'
 
-import { SnapshotProvider, SubsquidProvider } from '../src/sources'
+import { SNAPSHOT_CID_FIXTURE } from './fixtures/snapshot-cid-fixture'
 
-dotenv.config()
-
-const SUBSQUID_SEPOLIA_ENDPOINT = 'https://rail-squid.squids.live/squid-railgun-eth-sepolia-v2/graphql'
-const TEST_IPFS_HASH = 'QmNmjsFruGJ7dVtMPHA5EwikWapBoTz3jzUg6xoNCSGcR4'
-const TEST_START_HEIGHT = 5784866n
-const TEST_END_HEIGHT = 6066713n
-const TEST_IPFS_GATEWAYS = [
-  'https://ipfs.io/ipfs/',
-  'https://gateway.pinata.cloud/ipfs/',
-  'https://cloudflare-ipfs.com/ipfs/',
-  'https://ipfs.public.cat/ipfs/'
-]
-
-const provider = new SnapshotProvider({
-  ipfsHash: TEST_IPFS_HASH,
-  gateways: TEST_IPFS_GATEWAYS,
+afterEach(() => {
+  mock.restoreAll()
 })
 
-describe('SnapshotProvider[EthereumSepolia]', () => {
-  before(async () => {
-    // Trigger lazy fetching of snapshot
-    await provider.head()
-  })
+const TEST_IPFS_GATEWAYS = ['https://gateway.test/ipfs/']
 
-  test('Should retrieve valid head for snapshot', async () => {
-    const head = await provider.head()
-    assert(head === TEST_END_HEIGHT, 'Head is invalid')
-  })
+/**
+ * Encode a producer-compatible DAG-CBOR fixture.
+ * @param value - Fixture value to encode.
+ * @returns DAG-CBOR bytes.
+ */
+async function encodeDagCbor (value: unknown): Promise<Uint8Array> {
+  const [
+    dagCbor,
+    { encode },
+    { bigIntEncoder }
+  ] = await Promise.all([
+    import('@ipld/dag-cbor'),
+    import('cborg'),
+    import('cborg/taglib')
+  ])
 
-  test('Should retrieve valid metadata for snapshot', async () => {
-    const snapshot = provider.snapshotContent
-
-    assert(snapshot != null)
-    assert(snapshot.version === 1)
-    assert(snapshot.chainID === 11155111)
-    assert(BigInt(snapshot.endHeight) === TEST_END_HEIGHT)
-    assert(BigInt(snapshot.startHeight) === TEST_START_HEIGHT)
-    assert(snapshot.entryCount === 14)
-    assert(snapshot.blocks.length === 10)
-  })
-
-  test('Should retrieve same data as graph provider for given block range', async () => {
-    const graphProvider = new SubsquidProvider(SUBSQUID_SEPOLIA_ENDPOINT)
-
-    const syncOptions = {
-      startHeight: TEST_START_HEIGHT,
-      endHeight: TEST_END_HEIGHT,
-      liveSync: false
+  return encode(value, {
+    ...dagCbor.encodeOptions,
+    typeEncoders: {
+      ...dagCbor.encodeOptions.typeEncoders,
+      bigint: bigIntEncoder
     }
+  })
+}
 
-    const graphEventsIterator = graphProvider.from(syncOptions)
-    const graphEvents = await Array.fromAsync(graphEventsIterator)
+/**
+ * Copy bytes into an ArrayBuffer suitable for a mocked fetch response.
+ * @param bytes - Response bytes.
+ * @returns Copied ArrayBuffer.
+ */
+function arrayBufferFromBytes (bytes: Uint8Array): ArrayBuffer {
+  return Uint8Array.from(bytes).buffer
+}
 
-    const snapshotEventsIterator = provider.from(syncOptions)
-    const snapshotEvents = await Array.fromAsync(snapshotEventsIterator)
+/**
+ * Mock fetch with a successful binary response.
+ * @param bytes - Response bytes.
+ */
+function mockFetchBytes (bytes: Uint8Array) {
+  mock.method(globalThis, 'fetch', async () => ({
+    ok: true,
+    status: 200,
+    /**
+     * Resolve to array buffer
+     * @returns - Array buffer
+     */
+    arrayBuffer: async () => arrayBufferFromBytes(bytes),
+  } as Response))
+}
 
-    assert.deepEqual(graphEvents, snapshotEvents)
+/**
+ * Create a provider whose expected CID matches mocked response bytes.
+ * @param bytes - Mocked response bytes.
+ * @param expectedCid - Optional expected CID override.
+ * @returns Configured snapshot provider.
+ */
+async function createProviderForBytes (
+  bytes: Uint8Array,
+  expectedCid?: string
+): Promise<SnapshotProvider<any>> {
+  mockFetchBytes(bytes)
+  return new SnapshotProvider({
+    ipfsHash: expectedCid ?? await dagCborCIDFromBytes(bytes),
+    gateways: TEST_IPFS_GATEWAYS
+  })
+}
+
+describe('SnapshotProvider DAG-CBOR decoding', () => {
+  test('Should match the shared producer CID fixture', async () => {
+    const bytes = Uint8Array.from(
+      Buffer.from(SNAPSHOT_CID_FIXTURE.artifactHex, 'hex')
+    )
+
+    assert.equal(
+      await dagCborCIDFromBytes(bytes),
+      SNAPSHOT_CID_FIXTURE.cid
+    )
+  })
+
+  test('Should reject a CID mismatch before decoding', async () => {
+    const invalidSnapshotBytes = new Uint8Array([1, 2, 3, 4])
+    const provider = await createProviderForBytes(
+      invalidSnapshotBytes,
+      SNAPSHOT_CID_FIXTURE.cid
+    )
+
+    await assert.rejects(
+      () => provider.head(),
+      (err) => {
+        return err instanceof Error &&
+          err.message.includes('Snapshot CID mismatch') &&
+          !err.message.includes('Failed to decode snapshot')
+      }
+    )
+  })
+
+  test('Should decode DAG-CBOR snapshots and preserve bigint height fields', async () => {
+    const testSnapshot = {
+      version: 1,
+      chainID: 1,
+      startHeight: 17000000n,
+      endHeight: 17000001n,
+      entryCount: 0,
+      blocks: [{
+        number: 17000000n,
+        hash: new Uint8Array([1]),
+        timestamp: 100n,
+        transactions: []
+      }]
+    }
+    const testCompressedBytes = brotliCompressSync(await encodeDagCbor(testSnapshot))
+    const provider = await createProviderForBytes(testCompressedBytes)
+    const head = await provider.head()
+    const events = await Array.fromAsync(provider.from({
+      startHeight: 17000000n,
+      endHeight: 17000001n,
+      liveSync: false
+    }))
+
+    assert.equal(head, 17000001n)
+    assert.equal(typeof provider.snapshotContent?.startHeight, 'bigint')
+    assert.equal(typeof provider.snapshotContent?.endHeight, 'bigint')
+    assert.equal(typeof provider.snapshotContent?.blocks[0]?.number, 'bigint')
+    assert.equal(events[0]?.number, 17000000n)
+  })
+
+  test('Should decode DAG-CBOR bignum tags emitted by the snapshot producer patch', async () => {
+    const largeAmount = 18446744073709551616n
+    const testSnapshot = {
+      version: 1,
+      chainID: 1,
+      startHeight: 1n,
+      endHeight: 1n,
+      entryCount: 1,
+      blocks: [{
+        number: 1n,
+        hash: new Uint8Array([1]),
+        timestamp: 100n,
+        transactions: [{
+          hash: new Uint8Array([2]),
+          index: 0,
+          from: new Uint8Array([3]),
+          actions: [[{
+            actionType: 'Unshield',
+            amount: largeAmount
+          }]]
+        }]
+      }]
+    }
+    const testCompressedBytes = brotliCompressSync(await encodeDagCbor(testSnapshot))
+    const provider = await createProviderForBytes(testCompressedBytes)
+    const events = await Array.fromAsync(provider.from({
+      startHeight: 1n,
+      endHeight: 1n,
+      liveSync: false
+    }))
+
+    assert.equal((events[0]?.transactions[0]?.actions[0]?.[0] as any).amount, largeAmount)
   })
 })
 
-describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
-  test('Should throw error in case of invalid ipfs hash', async () => {
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
-    await assert.rejects(provider.head(), /Failed to fetch snapshot/)
+describe('Should handle invalid snapshot', async () => {
+  test('Should throw error for an invalid expected CID', async () => {
+    const bytes = Uint8Array.from(
+      Buffer.from(SNAPSHOT_CID_FIXTURE.artifactHex, 'hex')
+    )
+    const provider = await createProviderForBytes(bytes, 'QInvalid')
+
+    await assert.rejects(
+      () => provider.head(),
+      /Invalid expected snapshot CID/
+    )
   })
 
   test('Should throw error in case of failed HTTP request', async () => {
@@ -84,41 +198,23 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       arrayBuffer: async () => new ArrayBuffer(0),
     } as Response))
 
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = new SnapshotProvider({
+      ipfsHash: SNAPSHOT_CID_FIXTURE.cid,
+      gateways: TEST_IPFS_GATEWAYS
+    })
     await assert.rejects(() => provider.head(), /Failed to fetch snapshot/)
   })
 
   test('Should throw error on invalid brotli compressed format', async () => {
     const testResponseBytes = new Uint8Array([1, 2, 3, 4])
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testResponseBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testResponseBytes)
     await assert.rejects(() => provider.head(), /Failed to decode snapshot/)
   })
 
-  test('Should throw error when cbor encoded payload is invalid', async () => {
+  test('Should throw error when DAG-CBOR encoded payload is invalid', async () => {
     const testCborEncodedBytes = new Uint8Array([1, 2, 3, 4])
     const testCompressedBytes = brotliCompressSync(testCborEncodedBytes)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(() => provider.head(), /Failed to decode snapshot/)
   })
 
@@ -130,20 +226,9 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       blocks: []
     }
 
-    const testEncodedSnapshot = encode(testSnapshot)
+    const testEncodedSnapshot = await encodeDagCbor(testSnapshot)
     const testCompressedBytes = brotliCompressSync(testEncodedSnapshot)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(
       () => provider.head(),
       (err) => {
@@ -163,20 +248,9 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       blocks: []
     }
 
-    const testEncodedSnapshot = encode(testSnapshot)
+    const testEncodedSnapshot = await encodeDagCbor(testSnapshot)
     const testCompressedBytes = brotliCompressSync(testEncodedSnapshot)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(
       () => provider.head(),
       (err) => {
@@ -197,20 +271,9 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       blocks: []
     }
 
-    const testEncodedSnapshot = encode(testSnapshot)
+    const testEncodedSnapshot = await encodeDagCbor(testSnapshot)
     const testCompressedBytes = brotliCompressSync(testEncodedSnapshot)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(
       () => provider.head(),
       (err) => {
@@ -218,6 +281,27 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
           err.message.includes('Failed to decode snapshot') &&
           err.cause instanceof Error &&
           err.cause.message.includes('startHeight cannot be greater than endHeight')
+      }
+    )
+  })
+
+  test('Should throw error when a numeric height is not a safe integer', async () => {
+    const testSnapshot = {
+      version: 1,
+      chainID: 1,
+      startHeight: Number.MAX_SAFE_INTEGER + 1,
+      endHeight: Number.MAX_SAFE_INTEGER + 1,
+      blocks: []
+    }
+    const testCompressedBytes = brotliCompressSync(await encodeDagCbor(testSnapshot))
+    const provider = await createProviderForBytes(testCompressedBytes)
+    await assert.rejects(
+      () => provider.head(),
+      (err) => {
+        return err instanceof Error &&
+          err.message.includes('Failed to decode snapshot') &&
+          err.cause instanceof Error &&
+          err.cause.message.includes('missing or invalid startHeight')
       }
     )
   })
@@ -230,20 +314,9 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       blocks: []
     }
 
-    const testEncodedSnapshot = encode(testSnapshot)
+    const testEncodedSnapshot = await encodeDagCbor(testSnapshot)
     const testCompressedBytes = brotliCompressSync(testEncodedSnapshot)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(
       () => provider.head(),
       (err) => {
@@ -263,20 +336,9 @@ describe('Should handle invalid snapshot[EthereumSepolia]', async () => {
       endHeight: 100,
     }
 
-    const testEncodedSnapshot = encode(testSnapshot)
+    const testEncodedSnapshot = await encodeDagCbor(testSnapshot)
     const testCompressedBytes = brotliCompressSync(testEncodedSnapshot)
-
-    mock.method(globalThis, 'fetch', async () => ({
-      ok: true,
-      status: 200,
-      /**
-       * Resolve to array buffer
-       * @returns - Array buffer
-       */
-      arrayBuffer: async () => testCompressedBytes.buffer,
-    } as Response))
-
-    const provider = new SnapshotProvider({ ipfsHash: 'QInvalid', gateways: TEST_IPFS_GATEWAYS })
+    const provider = await createProviderForBytes(testCompressedBytes)
     await assert.rejects(
       () => provider.head(),
       (err) => {


### PR DESCRIPTION
## Summary

  Verifies fetched snapshot artifacts against their CID before decoding, closing the
  content-addressing gap where the producer computed a CIDv1 as the artifact's
  identity but the consumer fetched by IPFS hash and never validated the bytes. A
  tampered or wrong artifact served by a gateway is now rejected before decode.

  Also promotes the CID helpers to scanner's public API so the snapshot CID has a
  single, scanner-owned home that the producer side can consume, rather than two
  copies drifting independently.

  ## Changes

  - Add `src/sources/snapshot/cid.ts` — `dagCborCIDFromBytes` and `verifyDagCborCID`
    computing a CIDv1 (dag-cbor, sha2-256) over the fetched artifact bytes, matching
    the producer's algorithm exactly.
  - `SnapshotProvider` now verifies the fetched bytes against the configured
    `ipfsHash` (treated as the expected CID) before decompression/decode, rejecting
    on mismatch with a clear error.
  - Export `dagCborCIDFromBytes` / `verifyDagCborCID` from the package public API.
  - Document the producer/consumer CID fixture as a cross-repo vector that must stay
    byte-identical, guarded by each repo's parity test.
